### PR TITLE
Add auto-pairs plugin to init.vim

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -24,6 +24,7 @@ Plug 'skalnik/vim-vroom'                " run tests
 Plug 'w0rp/ale'                         " linter
 Plug 'mhartington/oceanic-next'         " color scheme
 Plug 'vim-airline/vim-airline'
+Plug 'jiangmiao/auto-pairs'             " auto closing delimiters
 
 call plug#end()
 


### PR DESCRIPTION
Adds an auto-pairs plugin to the vim config, which will allow for auto
closing of parens, brackets, etc.

https://github.com/jiangmiao/auto-pairs